### PR TITLE
Generate router config from hardware placeholders

### DIFF
--- a/router/router.yaml
+++ b/router/router.yaml
@@ -12,9 +12,18 @@ endpoints:
   cpu: http://127.0.0.1:11436
 
 hardware:
-  gpu0: {name: RTX 2080 Ti, vram_gb: 11, est_tok_s: 40}
-  gpu1: {name: RTX 2060 12GB, vram_gb: 12, est_tok_s: 38}
-  cpu: {name: CPU, vram_gb: 0, est_tok_s: 9.5}
+  gpu0:
+    name: ${GPU0_NAME}
+    vram_gb: ${GPU0_VRAM}
+    est_tok_s: 40
+  gpu1:
+    name: ${GPU1_NAME}
+    vram_gb: ${GPU1_VRAM}
+    est_tok_s: 38
+  cpu:
+    name: ${CPU_NAME}
+    vram_gb: ${CPU_VRAM}
+    est_tok_s: 9.5
 
 # Map aliases (without :latest suffix) to endpoints.  The router will
 # normalise incoming model names by stripping ":latest" before

--- a/scripts/generate_router_config.py
+++ b/scripts/generate_router_config.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Generate router configuration from template with hardware placeholders."""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+from string import Template
+
+
+def _detect_gpus() -> list[dict[str, str]]:
+    """Return list of GPUs with name and VRAM in GB."""
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,memory.total",
+                "--format=csv,noheader",
+            ],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except Exception:
+        return []
+
+    gpus = []
+    for line in out.strip().splitlines():
+        try:
+            name, mem = [p.strip() for p in line.split(",", 1)]
+            # memory reported like "8192 MiB"
+            mem_mb = int(mem.split()[0])
+            mem_gb = str(int(mem_mb / 1024))
+            gpus.append({"name": name, "vram": mem_gb})
+        except Exception:
+            continue
+    return gpus
+
+
+def render(template: Path, output: Path) -> None:
+    gpus = _detect_gpus()
+
+    env = {
+        "CPU_NAME": os.environ.get("CPU_NAME", "CPU"),
+        "CPU_VRAM": os.environ.get("CPU_VRAM", "0"),
+    }
+    # ensure placeholders for at least two GPUs
+    for idx in range(max(2, len(gpus))):
+        if idx < len(gpus):
+            env[f"GPU{idx}_NAME"] = gpus[idx]["name"]
+            env[f"GPU{idx}_VRAM"] = gpus[idx]["vram"]
+        else:
+            env[f"GPU{idx}_NAME"] = os.environ.get(f"GPU{idx}_NAME", f"GPU{idx}")
+            env[f"GPU{idx}_VRAM"] = os.environ.get(f"GPU{idx}_VRAM", "0")
+
+    tpl = Template(template.read_text())
+    rendered = tpl.safe_substitute(env)
+    output.write_text(rendered)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("template", type=Path, help="Template router.yaml path")
+    ap.add_argument("output", type=Path, help="Output config path")
+    args = ap.parse_args()
+    render(args.template, args.output)

--- a/start_all.ps1
+++ b/start_all.ps1
@@ -129,8 +129,13 @@ $cmdCpu = @"
 "@
 Start-PSChild -Command $cmdCpu -WorkingDir $ollamaDir
 
-# Router (Python)
-Start-Exe -Exe $PythonExe -ArgList @($RouterPy, '--config', $RouterCfg) -WorkingDir $routerDir
+# Generate router config based on detected hardware
+$genCfg = Join-Path $routerDir 'router.generated.yaml'
+$genScript = Join-Path $PSScriptRoot 'scripts\generate_router_config.py'
+Start-Exe -Exe $PythonExe -ArgList @($genScript, $RouterCfg, $genCfg) -WorkingDir $PSScriptRoot
+
+# Router (Python) with generated config
+Start-Exe -Exe $PythonExe -ArgList @($RouterPy, '--config', $genCfg) -WorkingDir $routerDir
 
 # Evaluator proxy (FastAPI)
 $cmdEval = @"

--- a/start_all.sh
+++ b/start_all.sh
@@ -37,8 +37,13 @@ nohup env OLLAMA_HOST="127.0.0.1:$CPU_PORT" \
           OLLAMA_MODELS="$ROOT_DIR/OllamaCPU" \
           "$OLLAMA_BIN" serve >"$LOG_DIR/cpu.log" 2>&1 &
 
-# Start router
-nohup python "$ROOT_DIR/router/gar_router.py" --config "$ROOT_DIR/router/router.yaml" \
+# Generate router config based on detected hardware
+python "$ROOT_DIR/scripts/generate_router_config.py" \
+       "$ROOT_DIR/router/router.yaml" \
+       "$ROOT_DIR/router/router.generated.yaml"
+
+# Start router with generated config
+nohup python "$ROOT_DIR/router/gar_router.py" --config "$ROOT_DIR/router/router.generated.yaml" \
       >"$LOG_DIR/router.log" 2>&1 &
 
 # Start evaluator proxy


### PR DESCRIPTION
## Summary
- add GPU/CPU hardware placeholders to router configuration
- create script to fill placeholders from detected hardware
- run config generation in startup scripts before router launch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5709f364c832cb24f26d938236e53