### PR TITLE
docs: add full stack overview and annotate dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ router/         Heuristic router and YAML configuration
 ollama/         Example Modelfiles (e.g. custom assistant)
 SERVICES/       Windows service wrappers
 tests/          Basic load‑test scripts
+docs/           Project documentation and setup guides
+scripts/        Helper utilities and install scripts
 ```
+
+> 📚 **Looking for a full stack overview?** See
+> `docs/full-stack-overview.md` for a detailed reference of files,
+> paths, dependencies, and setup instructions.
 
 ## Quick start
 

--- a/docs/full-stack-overview.md
+++ b/docs/full-stack-overview.md
@@ -1,0 +1,98 @@
+# Full Stack Overview
+
+This document maps the GARVIS stack, outlining the purpose of each directory, the dependencies it uses, and how to set up the environment.
+
+## Prerequisites
+
+- Python 3.11+
+- [Ollama](https://ollama.com/) installed locally
+- Git
+
+## Directory structure
+
+| Path | Purpose |
+| --- | --- |
+| `OllamaCPU/`, `OllamaGPU0/`, `OllamaGPU1/` | Model stores for CPU and GPU-specific Ollama instances. Created automatically by the start scripts. |
+| `evaluator/` | FastAPI proxy mirroring Ollama `/api/generate` and logging routing decisions. |
+| `router/` | Heuristic router server and YAML configuration (`router.yaml`). |
+| `ollama/` | Example Modelfiles for custom models. |
+| `config/` | Environment templates and JSON configuration (`development.json`, `production.json`, `env.example`, `remote.env.example`, `schema.json`). |
+| `scripts/` | Utilities such as `install_dev_dependencies.sh`, `generate_router_config.py`, `hardware_inventory.py`, `validate_config.py`, `watchdog.sh`. |
+| `tests/` | Pytest suite and load-testing scripts. |
+| `docs/` | Documentation, including this guide, configuration reference, and remote setup. |
+| `SERVICES/` | Windows service wrappers. |
+| `tools/` | Helper PowerShell scripts (`analyze_logs.ps1`, `bench_ollama.ps1`). |
+| `start_all.sh`, `start_all.ps1` | Cross-platform scripts to launch the full stack. |
+| `garvis_validate.py` / `.ps1` | Stack validation utilities producing JSON reports. |
+| `.github/workflows/ci.yml` | GitHub Actions pipeline for linting and tests. |
+| `.pre-commit-config.yaml` | Pre-commit hooks configuration. |
+| `pyproject.toml` | Tooling configuration for Ruff, Black, Mypy, and Pytest. |
+
+## Dependencies
+
+Runtime dependency (`requirements.txt`):
+
+- `jsonschema` – runtime schema validation for configuration files.
+
+Development tools (`requirements-dev.txt`):
+
+- `pytest` – test runner
+- `pytest-cov` – coverage reporting for tests
+- `pyyaml` – YAML utilities
+- `jsonschema` – schema validation in tests
+- `ruff` – linting and code style checks
+- `black` – Python formatter
+- `mypy` – static type checking
+- `yamllint` – YAML linter
+- `pre-commit` – hook management
+- `fastapi` – evaluator proxy framework
+- `requests` – HTTP client for tests
+- `types-PyYAML`, `types-requests`, `types-jsonschema` – typing stubs
+
+Install all development dependencies with:
+
+```
+scripts/install_dev_dependencies.sh
+pre-commit install
+```
+
+## Setup
+
+1. Ensure Ollama and Python 3.11+ are installed.
+2. Install project dependencies:
+
+```
+scripts/install_dev_dependencies.sh
+```
+
+3. Start the stack:
+
+```
+./start_all.sh          # Linux/macOS
+# or
+Start-Process powershell -Verb RunAs -ArgumentList "-File start_all.ps1"  # Windows
+```
+
+The script boots Ollama instances for each GPU and the CPU, generates `router/router.generated.yaml`, then launches the router and evaluator services.
+
+## Testing and validation
+
+Run linters and tests:
+
+```
+pre-commit run --all-files
+pytest
+```
+
+Validate a running stack without altering state:
+
+```
+python garvis_validate.py
+```
+
+## Additional notes
+
+- `config/env` allows overriding default ports or the `ollama` binary path.
+- Logs are written under `logs/` during runtime.
+- Example Modelfiles reside in `ollama/` and can be customized.
+- For remote deployment guidelines see `docs/remote-setup.md`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,14 @@
-pytest==8.2.1
-pytest-cov==5.0.0
-pyyaml==6.0.1
-jsonschema==4.23.0
-ruff==0.4.8
-black==24.4.2
-mypy==1.10.0
-yamllint==1.35.1
-pre-commit==3.7.0
-fastapi==0.111.0
-requests==2.32.3
-types-PyYAML
-types-requests
-types-jsonschema
+pytest==8.2.1         # Test framework
+pytest-cov==5.0.0     # Coverage reporting for pytest
+pyyaml==6.0.1         # YAML parsing utilities
+jsonschema==4.23.0    # Schema validation for tests
+ruff==0.4.8           # Linting and code style checks
+black==24.4.2         # Python code formatter
+mypy==1.10.0          # Static type checking
+yamllint==1.35.1      # YAML file linter
+pre-commit==3.7.0     # Git pre-commit hook manager
+fastapi==0.111.0      # Evaluator proxy framework
+requests==2.32.3      # HTTP client for tests
+types-PyYAML          # Typing stubs for PyYAML
+types-requests        # Typing stubs for requests
+types-jsonschema      # Typing stubs for jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema>=4.0.0,<5
+jsonschema>=4.0.0,<5  # Runtime schema validation for configuration files


### PR DESCRIPTION
## Summary
- document repository structure, dependencies, and setup in `docs/full-stack-overview.md`
- link the new guide from README and note docs/scripts directories
- explain runtime and development dependencies directly in requirements files

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a645e81de8832ca2b289f3b14edba7